### PR TITLE
Add new biomes, NPC interactions, and battle flow

### DIFF
--- a/src/app/battleScreen/page.tsx
+++ b/src/app/battleScreen/page.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import Image from "next/image";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { battleEncounters } from "../game/eventData";
+import { DEFAULT_LEVEL } from "../game/mapData";
+
+interface AttackDefinition {
+  name: string;
+  power: number;
+  description?: string;
+}
+
+export default function BattleScreen() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const encounterId = searchParams.get("encounter") ?? "";
+  const returnLevel = searchParams.get("returnLevel") ?? DEFAULT_LEVEL.id;
+  const encounter = useMemo(
+    () => battleEncounters[encounterId],
+    [encounterId]
+  );
+
+  const [playerHp, setPlayerHp] = useState(() =>
+    encounter ? encounter.playerMaxHp : 0
+  );
+  const [enemyHp, setEnemyHp] = useState(() =>
+    encounter ? encounter.enemyMaxHp : 0
+  );
+  const [battleState, setBattleState] = useState<
+    "awaiting" | "ongoing" | "victory" | "defeat"
+  >(encounter ? "ongoing" : "awaiting");
+  const [log, setLog] = useState<string[]>(
+    encounter ? [encounter.introText] : []
+  );
+
+  useEffect(() => {
+    if (!encounter) {
+      setBattleState("awaiting");
+      setLog([]);
+      setPlayerHp(0);
+      setEnemyHp(0);
+      return;
+    }
+    setPlayerHp(encounter.playerMaxHp);
+    setEnemyHp(encounter.enemyMaxHp);
+    setBattleState("ongoing");
+    setLog([encounter.introText]);
+  }, [encounter]);
+
+  const handleAttack = useCallback(
+    (attack: AttackDefinition) => {
+      if (!encounter || battleState !== "ongoing") {
+        return;
+      }
+
+      const updates: string[] = [];
+      updates.push(
+        `Você usou ${attack.name}!${
+          attack.description ? ` ${attack.description}` : ""
+        }`
+      );
+
+      const nextEnemyHp = Math.max(0, enemyHp - attack.power);
+      let nextPlayerHp = playerHp;
+
+      if (nextEnemyHp <= 0) {
+        updates.push(`${encounter.enemyName} foi derrotado!`);
+        updates.push(encounter.victoryText);
+        setEnemyHp(nextEnemyHp);
+        setBattleState("victory");
+        setLog((prev) => [...prev, ...updates]);
+        return;
+      }
+
+      const enemyAttack =
+        encounter.enemyAttacks[
+          Math.floor(Math.random() * encounter.enemyAttacks.length)
+        ];
+      updates.push(
+        `${encounter.enemyName} usou ${enemyAttack.name}!${
+          enemyAttack.description ? ` ${enemyAttack.description}` : ""
+        }`
+      );
+      nextPlayerHp = Math.max(0, playerHp - enemyAttack.power);
+
+      if (nextPlayerHp <= 0) {
+        updates.push(encounter.defeatText);
+        setBattleState("defeat");
+      }
+
+      setEnemyHp(nextEnemyHp);
+      setPlayerHp(nextPlayerHp);
+      setLog((prev) => [...prev, ...updates]);
+    },
+    [battleState, encounter, enemyHp, playerHp]
+  );
+
+  const goBackToMap = useCallback(() => {
+    router.push(`/game?level=${returnLevel}`);
+  }, [returnLevel, router]);
+
+  const playerHpPercent = encounter
+    ? Math.max(0, Math.round((playerHp / encounter.playerMaxHp) * 100))
+    : 0;
+  const enemyHpPercent = encounter
+    ? Math.max(0, Math.round((enemyHp / encounter.enemyMaxHp) * 100))
+    : 0;
+
+  return (
+    <main className="min-h-screen bg-neutral-950 text-neutral-100 flex flex-col items-center justify-center p-6">
+      <div className="w-full max-w-4xl rounded-2xl border border-neutral-800 bg-neutral-900/80 p-6 shadow-2xl backdrop-blur">
+        {encounter ? (
+          <>
+            <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h1 className="text-2xl font-bold">Batalha contra {encounter.enemyName}</h1>
+                <p className="text-sm text-neutral-300">
+                  Escolha um ataque para vencer o duelo por turnos.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={goBackToMap}
+                className="rounded-md border border-blue-400 px-4 py-2 text-sm font-semibold text-blue-300 transition hover:bg-blue-500/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-400"
+              >
+                Fugir da batalha
+              </button>
+            </header>
+
+            <section className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-2">
+              <article className="rounded-lg border border-neutral-800 bg-neutral-900/90 p-4">
+                <h2 className="text-lg font-semibold">Você</h2>
+                <div className="mt-2 h-2 w-full rounded-full bg-neutral-800">
+                  <div
+                    className="h-2 rounded-full bg-emerald-400 transition-all"
+                    style={{ width: `${playerHpPercent}%` }}
+                  />
+                </div>
+                <p className="mt-1 text-sm text-neutral-300">
+                  HP: {playerHp} / {encounter.playerMaxHp}
+                </p>
+                <div className="mt-4 flex justify-center">
+                  <Image
+                    src="/characters/player-front.png"
+                    alt="Sprite do jogador"
+                    width={128}
+                    height={128}
+                    className="h-32 w-32 object-contain"
+                    priority
+                  />
+                </div>
+              </article>
+
+              <article className="rounded-lg border border-neutral-800 bg-neutral-900/90 p-4 text-right">
+                <h2 className="text-lg font-semibold">{encounter.enemyName}</h2>
+                <div className="mt-2 h-2 w-full rounded-full bg-neutral-800">
+                  <div
+                    className="h-2 rounded-full bg-rose-400 transition-all"
+                    style={{ width: `${enemyHpPercent}%` }}
+                  />
+                </div>
+                <p className="mt-1 text-sm text-neutral-300">
+                  HP: {enemyHp} / {encounter.enemyMaxHp}
+                </p>
+                <div className="mt-4 flex justify-center">
+                  <Image
+                    src={encounter.enemySprite}
+                    alt={`Sprite de ${encounter.enemyName}`}
+                    width={128}
+                    height={128}
+                    className="h-32 w-32 object-contain"
+                  />
+                </div>
+              </article>
+            </section>
+
+            <section className="mt-6 grid grid-cols-1 gap-3 md:grid-cols-3">
+              {encounter.playerAttacks.map((attack) => (
+                <button
+                  key={attack.name}
+                  type="button"
+                  onClick={() => handleAttack(attack)}
+                  disabled={battleState !== "ongoing"}
+                  className="rounded-lg border border-emerald-500 bg-emerald-600/20 px-4 py-3 text-left text-sm font-semibold text-emerald-200 shadow transition hover:bg-emerald-500/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-emerald-400 disabled:cursor-not-allowed disabled:border-neutral-700 disabled:text-neutral-500 disabled:hover:bg-transparent"
+                >
+                  <span className="block text-base">{attack.name}</span>
+                  {attack.description && (
+                    <span className="mt-1 block text-xs font-normal text-emerald-100/80">
+                      {attack.description}
+                    </span>
+                  )}
+                </button>
+              ))}
+            </section>
+
+            <section className="mt-6 h-48 overflow-y-auto rounded-lg border border-neutral-800 bg-neutral-900/90 p-4 text-sm leading-relaxed">
+              {log.map((line, index) => (
+                <p key={`${line}-${index}`} className="mb-2 last:mb-0">
+                  {line}
+                </p>
+              ))}
+            </section>
+
+            {battleState !== "ongoing" && (
+              <div className="mt-6 flex justify-end">
+                <button
+                  type="button"
+                  onClick={goBackToMap}
+                  className="rounded-md bg-blue-500 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-400"
+                >
+                  Retornar ao mapa
+                </button>
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="space-y-4 text-center">
+            <h2 className="text-2xl font-semibold">Nenhuma batalha ativa</h2>
+            <p className="text-sm text-neutral-300">
+              Volte ao mapa e converse com um desafiante para iniciar um duelo.
+            </p>
+            <button
+              type="button"
+              onClick={goBackToMap}
+              className="rounded-md bg-blue-500 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-400"
+            >
+              Voltar ao mapa
+            </button>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/game/eventData.ts
+++ b/src/app/game/eventData.ts
@@ -1,0 +1,284 @@
+export interface DialogueEntry {
+  id: string;
+  name: string;
+  lines: string[];
+}
+
+export interface AttackDefinition {
+  name: string;
+  power: number;
+  description?: string;
+}
+
+export interface BattleEncounter {
+  id: string;
+  enemyName: string;
+  enemySprite: string;
+  enemyMaxHp: number;
+  playerMaxHp: number;
+  enemyAttacks: AttackDefinition[];
+  playerAttacks: AttackDefinition[];
+  introText: string;
+  victoryText: string;
+  defeatText: string;
+}
+
+const defaultPlayerAttacks: AttackDefinition[] = [
+  {
+    name: "Leaf Slash",
+    power: 12,
+    description: "A sharp arc of verdant energy.",
+  },
+  {
+    name: "Starfall Pulse",
+    power: 16,
+    description: "Starlight condenses into a brilliant strike.",
+  },
+  {
+    name: "Gale Breaker",
+    power: 20,
+    description: "A roaring gust crashes into the foe.",
+  },
+];
+
+export const battleEncounters: Record<string, BattleEncounter> = {
+  "azure-wave-warden": {
+    id: "azure-wave-warden",
+    enemyName: "Wave Warden Lyss",
+    enemySprite: "/characters/wizard-purple.png",
+    enemyMaxHp: 42,
+    playerMaxHp: 60,
+    enemyAttacks: [
+      {
+        name: "Tidal Lash",
+        power: 12,
+        description: "Brackish water lashes like a whip.",
+      },
+      {
+        name: "Foam Burst",
+        power: 10,
+        description: "Effervescent bubbles detonate beneath your boots.",
+      },
+    ],
+    playerAttacks: defaultPlayerAttacks,
+    introText:
+      "Lyss twirls a coral staff as the tide surges around the dock.",
+    victoryText:
+      "Lyss nods approvingly. \"May the currents carry you safely to the dunes.\"",
+    defeatText:
+      "Dock hands rush to pull you from the surf. Better regroup before returning.",
+  },
+  "azure-tideguard": {
+    id: "azure-tideguard",
+    enemyName: "Tideguard Serrin",
+    enemySprite: "/characters/wizard-blue.png",
+    enemyMaxHp: 48,
+    playerMaxHp: 60,
+    enemyAttacks: [
+      {
+        name: "Shell Slam",
+        power: 13,
+        description: "A shield of seashells crashes forward.",
+      },
+      {
+        name: "Breaker Wave",
+        power: 15,
+        description: "A roaring wave threatens to sweep you away.",
+      },
+    ],
+    playerAttacks: defaultPlayerAttacks,
+    introText:
+      "Serrin plants an anchor spear and challenges you to weather the tide.",
+    victoryText:
+      "Serrin laughs heartily. \"You've the grit to survive the desert winds.\"",
+    defeatText:
+      "Salt spray stings your eyes as the guard signals a tactical retreat.",
+  },
+  "dune-duelist": {
+    id: "dune-duelist",
+    enemyName: "Bladesong Rhea",
+    enemySprite: "/characters/player-right.png",
+    enemyMaxHp: 54,
+    playerMaxHp: 68,
+    enemyAttacks: [
+      {
+        name: "Glass Edge",
+        power: 14,
+        description: "Hardened sand forms a gleaming blade.",
+      },
+      {
+        name: "Mirage Dash",
+        power: 16,
+        description: "A blur of heat and steel darts past your guard.",
+      },
+    ],
+    playerAttacks: defaultPlayerAttacks,
+    introText:
+      "Rhea traces patterns in the sand before lunging with dancer's grace.",
+    victoryText:
+      "She sheathes her blades. \"Carry our desert's song into the glade beyond.\"",
+    defeatText:
+      "Heat haze engulfs you as Rhea offers a hand to help you stand again.",
+  },
+  "beastmaster-kai": {
+    id: "beastmaster-kai",
+    enemyName: "Beastmaster Kai",
+    enemySprite: "/characters/character-sprite-image.png",
+    enemyMaxHp: 60,
+    playerMaxHp: 68,
+    enemyAttacks: [
+      {
+        name: "Pack Ambush",
+        power: 15,
+        description: "Echoing howls strike from every side.",
+      },
+      {
+        name: "Sandstorm Call",
+        power: 18,
+        description: "A spiraling squall pelts you with grit and stone.",
+      },
+    ],
+    playerAttacks: defaultPlayerAttacks,
+    introText:
+      "Kai whistles and the dunes rumble with the steps of hidden companions.",
+    victoryText:
+      "Kai grins. \"The glade will welcome a champion with your resolve.\"",
+    defeatText:
+      "You brace against the storm, vowing to return with a stronger stance.",
+  },
+  "glade-guardian": {
+    id: "glade-guardian",
+    enemyName: "Guardian Elowen",
+    enemySprite: "/characters/player-character-front.png",
+    enemyMaxHp: 65,
+    playerMaxHp: 75,
+    enemyAttacks: [
+      {
+        name: "Lumen Arrow",
+        power: 16,
+        description: "A radiant arrow streaks across the grove.",
+      },
+      {
+        name: "Verdant Shield",
+        power: 18,
+        description: "Roots surge up in a protective wave.",
+      },
+    ],
+    playerAttacks: defaultPlayerAttacks,
+    introText:
+      "Elowen tests your aura, branches bending toward her call.",
+    victoryText:
+      "She bows deeply. \"The glade recognizes your harmony with its light.\"",
+    defeatText:
+      "The grove hums softly, urging you to regain your balance before returning.",
+  },
+  "glade-seer": {
+    id: "glade-seer",
+    enemyName: "Seer Vaela",
+    enemySprite: "/characters/player-back.png",
+    enemyMaxHp: 70,
+    playerMaxHp: 75,
+    enemyAttacks: [
+      {
+        name: "Moonpetal Flare",
+        power: 18,
+        description: "Moonlit petals explode in dazzling light.",
+      },
+      {
+        name: "Chrono Whorl",
+        power: 20,
+        description: "Time skips as a spiral of magic unravels your stance.",
+      },
+    ],
+    playerAttacks: defaultPlayerAttacks,
+    introText:
+      "Vaela's gaze pierces through timelines before she raises her staff.",
+    victoryText:
+      "Vaela smiles knowingly. \"Circle back to the fields—your journey has only begun.\"",
+    defeatText:
+      "The seer cradles you in shimmering light, sending you back to recover.",
+  },
+};
+
+export const npcDialogues: Record<string, DialogueEntry> = {
+  "grove-sage": {
+    id: "grove-sage",
+    name: "Aeliana the Grove Sage",
+    lines: [
+      "The fields are stirring with rumors of distant biomes.",
+      "Seek the waystones when you're ready to wander beyond this meadow.",
+    ],
+  },
+  "azure-chronicler": {
+    id: "azure-chronicler",
+    name: "Marin the Chronicler",
+    lines: [
+      "Every tide etches a new entry in our ledgers.",
+      "Mind the slick planks—some lead to hidden coves brimming with lore.",
+    ],
+  },
+  "azure-cartographer": {
+    id: "azure-cartographer",
+    name: "Ryn the Cartographer",
+    lines: [
+      "I chart the currents that spiral out toward the dunes.",
+      "Follow the waystone atop the long pier when you're ready to brave the heat.",
+    ],
+  },
+  "azure-bard": {
+    id: "azure-bard",
+    name: "Lysa the Harbor Bard",
+    lines: [
+      "I sing for sailors watching the horizon.",
+      "Bring back a melody from the desert and I'll weave it into tonight's song.",
+    ],
+  },
+  "desert-storyteller": {
+    id: "desert-storyteller",
+    name: "Sahir the Storyteller",
+    lines: [
+      "Every dune hides a legend beneath its crest.",
+      "Trade me tales of the sea and I'll share whispers of the glowing grove ahead.",
+    ],
+  },
+  "desert-navigator": {
+    id: "desert-navigator",
+    name: "Iria the Navigator",
+    lines: [
+      "The winds carve paths that only keen eyes notice.",
+      "Keep your bearings on the cairns if a sandstorm rises suddenly.",
+    ],
+  },
+  "desert-oracle": {
+    id: "desert-oracle",
+    name: "Oracle Nadir",
+    lines: [
+      "Starlight pools beneath the dunes at dusk.",
+      "Touch the crystalline waystone once your spirit resonates with the desert.",
+    ],
+  },
+  "glade-historian": {
+    id: "glade-historian",
+    name: "Eloi the Historian",
+    lines: [
+      "The glade blooms in cycles older than any kingdom.",
+      "Record what you witness—memories keep the lights aglow.",
+    ],
+  },
+  "glade-songweaver": {
+    id: "glade-songweaver",
+    name: "Nyra the Songweaver",
+    lines: [
+      "Every petal hums a note only travelers can hear.",
+      "Share a verse from the dunes and I'll braid it into a lullaby for the grove.",
+    ],
+  },
+  "glade-caretaker": {
+    id: "glade-caretaker",
+    name: "Caretaker Moss",
+    lines: [
+      "We nurture seedlings brought from every biome.",
+      "When you're ready to return to the fields, the eastern waystone will guide you.",
+    ],
+  },
+};

--- a/src/app/game/gameCanvas.tsx
+++ b/src/app/game/gameCanvas.tsx
@@ -6,13 +6,17 @@ import React, {
   useCallback,
   useMemo,
 } from "react";
+import { useRouter } from "next/navigation";
 import {
   tileColors,
   tileDefinitions,
   TILE_SIZE,
   DEFAULT_LEVEL,
   LevelDefinition,
+  TileDefinition,
+  TileEvent,
 } from "./mapData";
+import { battleEncounters, npcDialogues, DialogueEntry } from "./eventData";
 
 // type for loaded images
 type LoadedTileImages = Record<number, HTMLImageElement>;
@@ -28,10 +32,24 @@ const PLAYER_IMAGE_PATHS: Record<Direction, string> = {
 
 interface GameCanvasProps {
   level?: LevelDefinition;
+  entryPosition?: { row: number; col: number };
+  onLevelChange?: (transition: {
+    targetLevelId: string;
+    spawn?: { row: number; col: number };
+  }) => void;
+  onDialogue?: (dialogue: DialogueEntry) => void;
+  isInputDisabled?: boolean;
 }
 
-export default function GameCanvas({ level }: GameCanvasProps) {
+export default function GameCanvas({
+  level,
+  entryPosition,
+  onLevelChange,
+  onDialogue,
+  isInputDisabled = false,
+}: GameCanvasProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const router = useRouter();
   const [loadedImages, setLoadedImages] = useState<LoadedTileImages | null>(
     null
   );
@@ -48,8 +66,13 @@ export default function GameCanvas({ level }: GameCanvasProps) {
     [activeLevel]
   );
 
+  const effectiveEntry = useMemo(
+    () => entryPosition ?? startingPosition,
+    [entryPosition, startingPosition]
+  );
+
   const [playerTile, setPlayerTile] = useState<{ row: number; col: number }>(
-    startingPosition
+    () => ({ ...effectiveEntry })
   );
   const [dir, setDir] = useState<Direction>("down");
   const [playerImages, setPlayerImages] = useState<
@@ -57,9 +80,9 @@ export default function GameCanvas({ level }: GameCanvasProps) {
   >({});
 
   useEffect(() => {
-    setPlayerTile(startingPosition);
+    setPlayerTile({ row: effectiveEntry.row, col: effectiveEntry.col });
     setDir("down");
-  }, [startingPosition]);
+  }, [effectiveEntry.row, effectiveEntry.col]);
 
   // Effect for loading images
   useEffect(() => {
@@ -74,7 +97,7 @@ export default function GameCanvas({ level }: GameCanvasProps) {
         img.onload = () => resolve();
         img.onerror = (err) => {
           console.error(`Failed to load image for tile: ${tile.name}`, err);
-          resolve(); // Resolve even on error to allow fallback color, or reject to indicate a loading failure.
+          resolve();
         };
         img.src = tile.imagePath;
       });
@@ -109,10 +132,9 @@ export default function GameCanvas({ level }: GameCanvasProps) {
   // Effect for setting initial canvas size and handling resize
   useEffect(() => {
     function updateCanvasSize() {
-      // Consider basing size on viewport or container if needed
       setCanvasSize({
-        width: 800, // Or window.innerWidth
-        height: 600, // Or window.innerHeight
+        width: 800,
+        height: 600,
       });
     }
     updateCanvasSize();
@@ -120,40 +142,139 @@ export default function GameCanvas({ level }: GameCanvasProps) {
     return () => window.removeEventListener("resize", updateCanvasSize);
   }, []);
 
-  //Create a Set of walkable tiles once on mount
   const WALKABLE = useMemo(
     () => new Set(tileDefinitions.filter((t) => t.walkable).map((t) => t.id)),
     []
   );
 
-  // Memoize attemptMove to prevent redefining it on every render
+  const tileDefinitionMap = useMemo(() => {
+    const map = new Map<number, TileDefinition>();
+    tileDefinitions.forEach((tile) => {
+      map.set(tile.id, tile);
+    });
+    return map;
+  }, []);
+
   const attemptMove = useCallback(
     (deltaRow: number, deltaCol: number) => {
       setPlayerTile((pos) => {
         const newRow = pos.row + deltaRow;
         const newCol = pos.col + deltaCol;
 
-        // Bounds check
         if (newRow < 0 || newRow >= rows || newCol < 0 || newCol >= cols) {
           return pos; // out of map
         }
 
-        // Collision check
         const tileId = mapGrid[newRow][newCol];
         if (!WALKABLE.has(tileId)) {
           return pos; // blocked
         }
 
-        // Otherwise, move
         return { row: newRow, col: newCol };
       });
     },
     [cols, mapGrid, rows, WALKABLE]
-  ); // Include dependencies if they were used inside (rows, cols are used)
+  );
+
+  const handleTileEvent = useCallback(
+    (tileDef: TileDefinition, event: TileEvent) => {
+      switch (event.type) {
+        case "levelTransition": {
+          if (!event.targetLevelId) {
+            return;
+          }
+          onLevelChange?.({
+            targetLevelId: event.targetLevelId,
+            spawn: event.spawn,
+          });
+          break;
+        }
+        case "dialogue": {
+          const dialogue = npcDialogues[event.npcId];
+          if (dialogue) {
+            onDialogue?.(dialogue);
+          } else if (onDialogue) {
+            onDialogue({
+              id: event.npcId,
+              name: tileDef.name,
+              lines: ["..."],
+            });
+          }
+          break;
+        }
+        case "battle": {
+          const encounter = battleEncounters[event.encounterId];
+          if (!encounter) {
+            console.warn(`Encounter not found: ${event.encounterId}`);
+            return;
+          }
+          const params = new URLSearchParams();
+          params.set("encounter", event.encounterId);
+          params.set("returnLevel", activeLevel.id);
+          router.push(`/battleScreen?${params.toString()}`);
+          break;
+        }
+      }
+    },
+    [activeLevel.id, onDialogue, onLevelChange, router]
+  );
+
+  const lastTransitionKey = useRef<string | null>(null);
+  useEffect(() => {
+    const tileId = mapGrid[playerTile.row]?.[playerTile.col];
+    if (tileId === undefined) {
+      lastTransitionKey.current = null;
+      return;
+    }
+    const tileDef = tileDefinitionMap.get(tileId);
+    if (!tileDef?.event || tileDef.event.type !== "levelTransition") {
+      lastTransitionKey.current = null;
+      return;
+    }
+    const key = `${playerTile.row}:${playerTile.col}:${tileId}`;
+    if (lastTransitionKey.current === key) {
+      return;
+    }
+    lastTransitionKey.current = key;
+    handleTileEvent(tileDef, tileDef.event);
+  }, [handleTileEvent, mapGrid, playerTile, tileDefinitionMap]);
+
+  const interactWithFacingTile = useCallback(() => {
+    const offsets: Record<Direction, { row: number; col: number }> = {
+      down: { row: 1, col: 0 },
+      up: { row: -1, col: 0 },
+      left: { row: 0, col: -1 },
+      right: { row: 0, col: 1 },
+    };
+    const offset = offsets[dir];
+    const targetRow = playerTile.row + offset.row;
+    const targetCol = playerTile.col + offset.col;
+
+    if (
+      targetRow < 0 ||
+      targetRow >= rows ||
+      targetCol < 0 ||
+      targetCol >= cols
+    ) {
+      return;
+    }
+
+    const tileId = mapGrid[targetRow][targetCol];
+    const tileDef = tileDefinitionMap.get(tileId);
+    if (!tileDef?.event) {
+      return;
+    }
+
+    if (tileDef.event.type === "levelTransition") {
+      // Players trigger level transitions by stepping onto the tile, not interacting.
+      return;
+    }
+
+    handleTileEvent(tileDef, tileDef.event);
+  }, [cols, dir, handleTileEvent, mapGrid, playerTile, rows, tileDefinitionMap]);
 
   // Drawing Effect
   useEffect(() => {
-    // Checking if everything is loaded and canvas is ready
     if (
       !loadedImages ||
       !canvasRef.current ||
@@ -167,63 +288,50 @@ export default function GameCanvas({ level }: GameCanvasProps) {
 
     const canvas = canvasRef.current;
     const ctx = canvas.getContext("2d");
-    if (!ctx) return; // Important check
+    if (!ctx) return;
 
-    // Clear the entire canvas
     ctx.clearRect(0, 0, canvasSize.width, canvasSize.height);
 
     const mapWidth = cols * tileSize;
     const mapHeight = rows * tileSize;
 
-    // Center the camera on the player tile
     let cameraX =
       playerTile.col * tileSize - canvasSize.width / 2 + tileSize / 2;
     let cameraY =
       playerTile.row * tileSize - canvasSize.height / 2 + tileSize / 2;
 
-    // clamp so camera never goes beyond the map
     cameraX = Math.max(0, Math.min(cameraX, mapWidth - canvasSize.width));
     cameraY = Math.max(0, Math.min(cameraY, mapHeight - canvasSize.height));
 
-    // which tile index is at top-left of the camera
     const startCol = Math.floor(cameraX / tileSize);
     const startRow = Math.floor(cameraY / tileSize);
 
-    // how many tiles fit on-screen (+2 for buffer when scrolling)
     const visibleCols = Math.ceil(canvas.width / tileSize) + 2;
     const visibleRows = Math.ceil(canvas.height / tileSize) + 2;
 
-    // Disable image smoothing for pixel art
     ctx.imageSmoothingEnabled = false;
 
-    // Draw map tiles
     for (let row = startRow; row < startRow + visibleRows; row++) {
       for (let col = startCol; col < startCol + visibleCols; col++) {
-        // Check if the tile is within the map boundaries
         if (
           row < 0 ||
           row >= mapGrid.length ||
           col < 0 ||
           col >= mapGrid[0].length
         ) {
-          continue; // Skip drawing if outside map bounds
+          continue;
         }
 
         const tileType = mapGrid[row][col];
-
-        // Look up the tile definition to get the scale (default is 1 if not specified)
-        const tileDef = tileDefinitions.find((t) => t.id === tileType);
+        const tileDef = tileDefinitionMap.get(tileType);
         const scale = tileDef?.scale ?? 1;
         const drawSize = tileSize * scale;
-        // Center the scaled tile within the grid cell
         const offset = (drawSize - tileSize) / 2;
         const drawX = Math.floor(col * tileSize - cameraX) - offset;
         const drawY = Math.floor(row * tileSize - cameraY) - offset;
 
-        // Get the loaded image for this tile type
         const tileImg = loadedImages[tileType];
 
-        // Draw the tile image with scaling or fallback to a filled rectangle
         if (tileImg && tileImg.complete && tileImg.naturalHeight !== 0) {
           ctx.drawImage(tileImg, drawX, drawY, drawSize, drawSize);
         } else {
@@ -233,7 +341,6 @@ export default function GameCanvas({ level }: GameCanvasProps) {
       }
     }
 
-    // Draw Player
     const img = playerImages[dir];
     const playerScreenX = Math.floor(playerTile.col * tileSize - cameraX);
     const playerScreenY = Math.floor(playerTile.row * tileSize - cameraY);
@@ -241,15 +348,8 @@ export default function GameCanvas({ level }: GameCanvasProps) {
     const playerHeight = tileSize;
 
     if (img && img.complete && img.naturalHeight !== 0) {
-      ctx.drawImage(
-        img,
-        playerScreenX,
-        playerScreenY,
-        playerWidth,
-        playerHeight
-      );
+      ctx.drawImage(img, playerScreenX, playerScreenY, playerWidth, playerHeight);
     } else {
-      // Fallback
       ctx.fillStyle = "blue";
       ctx.fillRect(playerScreenX, playerScreenY, tileSize, tileSize);
     }
@@ -263,42 +363,53 @@ export default function GameCanvas({ level }: GameCanvasProps) {
     rows,
     cols,
     mapGrid,
+    tileDefinitionMap,
   ]);
 
-  // Keyboard Input Effect
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
+      if (isInputDisabled) {
+        return;
+      }
+
       switch (e.key) {
         case "ArrowUp":
         case "w":
+          e.preventDefault();
           setDir("up");
           attemptMove(-1, 0);
           break;
         case "ArrowDown":
         case "s":
+          e.preventDefault();
           setDir("down");
           attemptMove(1, 0);
           break;
         case "ArrowLeft":
         case "a":
+          e.preventDefault();
           setDir("left");
           attemptMove(0, -1);
           break;
         case "ArrowRight":
         case "d":
+          e.preventDefault();
           setDir("right");
           attemptMove(0, 1);
+          break;
+        case " ":
+        case "Enter":
+          e.preventDefault();
+          interactWithFacingTile();
           break;
         default:
           break;
       }
     }
     window.addEventListener("keydown", handleKeyDown);
-    // Cleanup: Remove listener when component unmounts
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [attemptMove]); // Add attemptMove as a dependency because it's defined outside
+  }, [attemptMove, interactWithFacingTile, isInputDisabled]);
 
-  // Render the Canvas
   return (
     <canvas
       ref={canvasRef}

--- a/src/app/game/mapData.tsx
+++ b/src/app/game/mapData.tsx
@@ -2,101 +2,519 @@
 
 export const TILE_SIZE = 32;
 
+const TILES = {
+  GRASS: 0,
+  BOULDER: 1,
+  COBBLESTONE: 2,
+  WATER: 3,
+  GROVE_SAGE: 4,
+  VERDANT_GATE: 5,
+  SAND: 6,
+  SANDSTONE_SPIRE: 7,
+  OASIS_WATER: 8,
+  AZURE_GATE: 9,
+  AZURE_CHRONICLER: 11,
+  AZURE_SENTINEL: 12,
+  AZURE_CARTOGRAPHER: 13,
+  AZURE_TIDEGUARD: 14,
+  AZURE_BARD: 15,
+  DESERT_STORYTELLER: 16,
+  DESERT_DUELIST: 17,
+  DESERT_NAVIGATOR: 18,
+  DESERT_BEASTMASTER: 19,
+  DESERT_ORACLE: 20,
+  GLADE_GRASS: 21,
+  GLADE_TREE: 22,
+  GLADE_WATER: 23,
+  GLADE_GATE: 24,
+  GLADE_HISTORIAN: 25,
+  GLADE_GUARDIAN: 26,
+  GLADE_SONGWEAVER: 27,
+  GLADE_SEER: 28,
+  GLADE_CARETAKER: 29,
+  DESERT_GATE: 30,
+} as const;
+
 export const tileColors: Record<number, string> = {
-  0: "#6abe30",
-  1: "#4d3827",
-  2: "#c4b28a",
-  3: "#3b6db0",
-  4: "#b75cff",
+  [TILES.GRASS]: "#6abe30",
+  [TILES.BOULDER]: "#4d3827",
+  [TILES.COBBLESTONE]: "#c4b28a",
+  [TILES.WATER]: "#3b6db0",
+  [TILES.GROVE_SAGE]: "#b75cff",
+  [TILES.VERDANT_GATE]: "#9cd6f4",
+  [TILES.SAND]: "#d7a75a",
+  [TILES.SANDSTONE_SPIRE]: "#8f5e2b",
+  [TILES.OASIS_WATER]: "#1f7fad",
+  [TILES.AZURE_GATE]: "#6fb6ff",
+  [TILES.AZURE_CHRONICLER]: "#91b4ff",
+  [TILES.AZURE_SENTINEL]: "#6aa4ff",
+  [TILES.AZURE_CARTOGRAPHER]: "#87c9ff",
+  [TILES.AZURE_TIDEGUARD]: "#4f9cff",
+  [TILES.AZURE_BARD]: "#79a9ff",
+  [TILES.DESERT_STORYTELLER]: "#d7b07a",
+  [TILES.DESERT_DUELIST]: "#d48d52",
+  [TILES.DESERT_NAVIGATOR]: "#d3a06b",
+  [TILES.DESERT_BEASTMASTER]: "#c57d3b",
+  [TILES.DESERT_ORACLE]: "#e0c278",
+  [TILES.GLADE_GRASS]: "#8de070",
+  [TILES.GLADE_TREE]: "#427331",
+  [TILES.GLADE_WATER]: "#5ad3f3",
+  [TILES.GLADE_GATE]: "#b6f2ff",
+  [TILES.GLADE_HISTORIAN]: "#7ce4a0",
+  [TILES.GLADE_GUARDIAN]: "#66c58a",
+  [TILES.GLADE_SONGWEAVER]: "#94e0c5",
+  [TILES.GLADE_SEER]: "#5fbf91",
+  [TILES.GLADE_CARETAKER]: "#82f0bc",
+  [TILES.DESERT_GATE]: "#f0d28d",
 };
+
+export type TileEvent =
+  | {
+      type: "levelTransition";
+      targetLevelId: string;
+      spawn?: { row: number; col: number };
+    }
+  | { type: "dialogue"; npcId: string }
+  | { type: "battle"; encounterId: string };
 
 export interface TileDefinition {
   id: number;
   name: string;
   imagePath: string;
   walkable: boolean;
-  eventTrigger?: boolean;
+  event?: TileEvent;
   scale?: number;
 }
 
 export const tileDefinitions: TileDefinition[] = [
   {
-    id: 0,
+    id: TILES.GRASS,
     name: "grass",
     imagePath: "/tiles/grass-tile-5.png",
     walkable: true,
   },
   {
-    id: 1,
+    id: TILES.BOULDER,
     name: "boulder",
     imagePath: "/tiles/rock-obstacle-tile.png",
     walkable: false,
   },
   {
-    id: 2,
+    id: TILES.COBBLESTONE,
     name: "cobblestone-path",
     imagePath: "/tiles/cobblestone-path-tile.png",
     walkable: true,
   },
   {
-    id: 3,
+    id: TILES.WATER,
     name: "water",
     imagePath: "/tiles/water-tile-1.png",
     walkable: false,
   },
   {
-    id: 4,
-    name: "wizard-blue-npc",
+    id: TILES.GROVE_SAGE,
+    name: "grove-sage",
     imagePath: "/characters/wizard-blue.png",
     walkable: false,
-    eventTrigger: true,
     scale: 1.6,
+    event: { type: "dialogue", npcId: "grove-sage" },
+  },
+  {
+    id: TILES.VERDANT_GATE,
+    name: "verdant-waystone",
+    imagePath: "/globe.svg",
+    walkable: true,
+    scale: 1.3,
+    event: {
+      type: "levelTransition",
+      targetLevelId: "azure-approach",
+      spawn: { row: 4, col: 3 },
+    },
+  },
+  {
+    id: TILES.SAND,
+    name: "sand",
+    imagePath: "/tiles/sand-tile-1.png",
+    walkable: true,
+  },
+  {
+    id: TILES.SANDSTONE_SPIRE,
+    name: "sandstone-spire",
+    imagePath: "/tiles/rock-tile-1.png",
+    walkable: false,
+  },
+  {
+    id: TILES.OASIS_WATER,
+    name: "oasis-water",
+    imagePath: "/tiles/water-tile-2.png",
+    walkable: false,
+  },
+  {
+    id: TILES.AZURE_GATE,
+    name: "azure-waystone",
+    imagePath: "/globe.svg",
+    walkable: true,
+    scale: 1.3,
+    event: {
+      type: "levelTransition",
+      targetLevelId: "crimson-dunes",
+      spawn: { row: 3, col: 3 },
+    },
+  },
+  {
+    id: TILES.AZURE_CHRONICLER,
+    name: "azure-chronicler",
+    imagePath: "/characters/wizard-purple.png",
+    walkable: false,
+    scale: 1.55,
+    event: { type: "dialogue", npcId: "azure-chronicler" },
+  },
+  {
+    id: TILES.AZURE_SENTINEL,
+    name: "azure-sentinel",
+    imagePath: "/characters/player-left.png",
+    walkable: false,
+    scale: 1.45,
+    event: { type: "battle", encounterId: "azure-wave-warden" },
+  },
+  {
+    id: TILES.AZURE_CARTOGRAPHER,
+    name: "azure-cartographer",
+    imagePath: "/characters/character-sprite-image.png",
+    walkable: false,
+    scale: 1.4,
+    event: { type: "dialogue", npcId: "azure-cartographer" },
+  },
+  {
+    id: TILES.AZURE_TIDEGUARD,
+    name: "azure-tideguard",
+    imagePath: "/characters/player-right.png",
+    walkable: false,
+    scale: 1.45,
+    event: { type: "battle", encounterId: "azure-tideguard" },
+  },
+  {
+    id: TILES.AZURE_BARD,
+    name: "azure-bard",
+    imagePath: "/characters/player-back.png",
+    walkable: false,
+    scale: 1.45,
+    event: { type: "dialogue", npcId: "azure-bard" },
+  },
+  {
+    id: TILES.DESERT_STORYTELLER,
+    name: "desert-storyteller",
+    imagePath: "/characters/player-front.png",
+    walkable: false,
+    scale: 1.45,
+    event: { type: "dialogue", npcId: "desert-storyteller" },
+  },
+  {
+    id: TILES.DESERT_DUELIST,
+    name: "desert-duelist",
+    imagePath: "/characters/player-character-front.png",
+    walkable: false,
+    scale: 1.45,
+    event: { type: "battle", encounterId: "dune-duelist" },
+  },
+  {
+    id: TILES.DESERT_NAVIGATOR,
+    name: "desert-navigator",
+    imagePath: "/characters/wizard-blue.png",
+    walkable: false,
+    scale: 1.5,
+    event: { type: "dialogue", npcId: "desert-navigator" },
+  },
+  {
+    id: TILES.DESERT_BEASTMASTER,
+    name: "desert-beastmaster",
+    imagePath: "/characters/character-sprite-image.png",
+    walkable: false,
+    scale: 1.5,
+    event: { type: "battle", encounterId: "beastmaster-kai" },
+  },
+  {
+    id: TILES.DESERT_ORACLE,
+    name: "desert-oracle",
+    imagePath: "/characters/wizard-purple.png",
+    walkable: false,
+    scale: 1.55,
+    event: { type: "dialogue", npcId: "desert-oracle" },
+  },
+  {
+    id: TILES.DESERT_GATE,
+    name: "desert-waystone",
+    imagePath: "/globe.svg",
+    walkable: true,
+    scale: 1.3,
+    event: {
+      type: "levelTransition",
+      targetLevelId: "luminous-glade",
+      spawn: { row: 3, col: 3 },
+    },
+  },
+  {
+    id: TILES.GLADE_GRASS,
+    name: "glade-grass",
+    imagePath: "/tiles/grass-flower-tile-1.png",
+    walkable: true,
+  },
+  {
+    id: TILES.GLADE_TREE,
+    name: "glade-tree",
+    imagePath: "/tiles/bush-tile-2.png",
+    walkable: false,
+  },
+  {
+    id: TILES.GLADE_WATER,
+    name: "glade-water",
+    imagePath: "/tiles/water-tile-3.png",
+    walkable: false,
+  },
+  {
+    id: TILES.GLADE_GATE,
+    name: "glade-waystone",
+    imagePath: "/globe.svg",
+    walkable: true,
+    scale: 1.3,
+    event: {
+      type: "levelTransition",
+      targetLevelId: "verdant-fields",
+      spawn: { row: 2, col: 3 },
+    },
+  },
+  {
+    id: TILES.GLADE_HISTORIAN,
+    name: "glade-historian",
+    imagePath: "/characters/player-left.png",
+    walkable: false,
+    scale: 1.45,
+    event: { type: "dialogue", npcId: "glade-historian" },
+  },
+  {
+    id: TILES.GLADE_GUARDIAN,
+    name: "glade-guardian",
+    imagePath: "/characters/player-character-front.png",
+    walkable: false,
+    scale: 1.5,
+    event: { type: "battle", encounterId: "glade-guardian" },
+  },
+  {
+    id: TILES.GLADE_SONGWEAVER,
+    name: "glade-songweaver",
+    imagePath: "/characters/player-back.png",
+    walkable: false,
+    scale: 1.45,
+    event: { type: "dialogue", npcId: "glade-songweaver" },
+  },
+  {
+    id: TILES.GLADE_SEER,
+    name: "glade-seer",
+    imagePath: "/characters/player-right.png",
+    walkable: false,
+    scale: 1.5,
+    event: { type: "battle", encounterId: "glade-seer" },
+  },
+  {
+    id: TILES.GLADE_CARETAKER,
+    name: "glade-caretaker",
+    imagePath: "/characters/player-front.png",
+    walkable: false,
+    scale: 1.45,
+    event: { type: "dialogue", npcId: "glade-caretaker" },
   },
 ];
 
-export const levelOneMap: number[][] = [
-  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-  [0, 0, 0, 0, 2, 2, 2, 2, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-  [0, 0, 1, 0, 2, 0, 0, 2, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 2, 2, 2, 2, 0, 0, 1, 0, 2, 0, 0, 2, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 2, 2, 2, 2, 0, 0],
-  [0, 2, 1, 0, 2, 0, 0, 2, 0, 0, 0, 4, 0, 0, 0, 1, 0, 0, 0, 0, 0, 2, 0, 0, 2, 0, 2, 1, 0, 2, 0, 0, 2, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 2, 0, 0, 2, 0, 0],
-  [0, 2, 1, 0, 2, 2, 2, 2, 2, 2, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 2, 0, 0, 2, 0, 2, 1, 0, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0],
-  [0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 2, 0, 0, 2, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 2, 0, 0, 2, 0, 0],
-  [0, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 0, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 2, 2, 2, 0, 0],
-  [0, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 2, 0, 0, 0, 0, 0],
-  [0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 2, 2, 0, 0, 0, 0, 0, 0, 0],
-  [0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-  [0, 0, 0, 0, 2, 2, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-  [0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 2, 2, 2, 2, 2, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 2, 2, 2, 2, 2, 0, 0],
-  [0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 2, 0, 0, 0, 0],
-  [0, 1, 0, 0, 1, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 1, 0, 0, 0, 0, 2, 0, 1, 0, 0, 1, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 1, 0, 0, 0, 0, 2, 0, 0],
-  [0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 2, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 2, 0, 0, 0, 0],
-  [0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 2, 0, 0, 0, 0],
-  [0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 2, 0, 0, 0, 0],
-  [0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 2, 0, 0, 0, 0],
-  [0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 2, 0, 0, 0, 0],
-]; //prettier-ignore
+function createFilledMap(width: number, height: number, fill: number): number[][] {
+  return Array.from({ length: height }, () => Array.from({ length: width }, () => fill));
+}
 
-export const levelTwoMap: number[][] = [
-  [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-  [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-  [1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-  [1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-  [1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-  [1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 2, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-  [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-  [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-  [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-  [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 2, 3, 3, 3, 0, 0, 0, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-  [1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 2, 3, 3, 3, 0, 0, 0, 3, 3, 3, 3, 0, 2, 2, 2, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 1],
-  [1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-  [1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1],
-  [1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1],
-  [1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1],
-  [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 4, 2, 2, 1, 1, 1, 1],
-  [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 2, 0, 0, 0, 0, 1],
-  [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 2, 0, 0, 0, 0, 1],
-  [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-]; //prettier-ignore
+function addBorder(map: number[][], tileId: number) {
+  const height = map.length;
+  const width = map[0]?.length ?? 0;
+  for (let col = 0; col < width; col++) {
+    map[0][col] = tileId;
+    map[height - 1][col] = tileId;
+  }
+  for (let row = 0; row < height; row++) {
+    map[row][0] = tileId;
+    map[row][width - 1] = tileId;
+  }
+}
+
+function fillRectangle(
+  map: number[][],
+  top: number,
+  left: number,
+  bottom: number,
+  right: number,
+  tileId: number
+) {
+  const height = map.length;
+  const width = map[0]?.length ?? 0;
+  const startRow = Math.max(0, Math.min(top, bottom));
+  const endRow = Math.min(height - 1, Math.max(top, bottom));
+  const startCol = Math.max(0, Math.min(left, right));
+  const endCol = Math.min(width - 1, Math.max(left, right));
+  for (let row = startRow; row <= endRow; row++) {
+    for (let col = startCol; col <= endCol; col++) {
+      map[row][col] = tileId;
+    }
+  }
+}
+
+function drawHorizontalPath(
+  map: number[][],
+  row: number,
+  startCol: number,
+  endCol: number,
+  tileId: number
+) {
+  fillRectangle(map, row, startCol, row, endCol, tileId);
+}
+
+function drawVerticalPath(
+  map: number[][],
+  col: number,
+  startRow: number,
+  endRow: number,
+  tileId: number
+) {
+  fillRectangle(map, startRow, col, endRow, col, tileId);
+}
+
+function placeTile(map: number[][], row: number, col: number, tileId: number) {
+  if (map[row]?.[col] !== undefined) {
+    map[row][col] = tileId;
+  }
+}
+
+function createVerdantFields(): number[][] {
+  const width = 24;
+  const height = 20;
+  const map = createFilledMap(width, height, TILES.GRASS);
+  addBorder(map, TILES.BOULDER);
+
+  fillRectangle(map, 3, 8, 5, 10, TILES.WATER);
+  fillRectangle(map, 7, 14, 8, 18, TILES.WATER);
+  fillRectangle(map, 12, 4, 13, 6, TILES.WATER);
+
+  drawVerticalPath(map, 3, 1, 16, TILES.COBBLESTONE);
+  drawHorizontalPath(map, 10, 3, 16, TILES.COBBLESTONE);
+  drawHorizontalPath(map, 16, 3, 19, TILES.COBBLESTONE);
+  drawVerticalPath(map, 20, 13, 16, TILES.COBBLESTONE);
+
+  placeTile(map, 5, 12, TILES.GROVE_SAGE);
+  placeTile(map, 9, 5, TILES.BOULDER);
+  placeTile(map, 11, 7, TILES.BOULDER);
+  placeTile(map, 6, 16, TILES.BOULDER);
+  placeTile(map, 14, 8, TILES.BOULDER);
+  placeTile(map, 8, 13, TILES.BOULDER);
+
+  placeTile(map, 15, 20, TILES.COBBLESTONE);
+  placeTile(map, 16, 19, TILES.COBBLESTONE);
+  placeTile(map, 17, 20, TILES.COBBLESTONE);
+  placeTile(map, 16, 20, TILES.VERDANT_GATE);
+
+  return map;
+}
+
+function createAzureApproach(): number[][] {
+  const width = 24;
+  const height = 20;
+  const map = createFilledMap(width, height, TILES.WATER);
+  addBorder(map, TILES.BOULDER);
+
+  drawHorizontalPath(map, 4, 2, width - 3, TILES.COBBLESTONE);
+  drawVerticalPath(map, 8, 4, 15, TILES.COBBLESTONE);
+  drawVerticalPath(map, 12, 4, 15, TILES.COBBLESTONE);
+  drawVerticalPath(map, 16, 4, 15, TILES.COBBLESTONE);
+  drawVerticalPath(map, 20, 4, 15, TILES.COBBLESTONE);
+  drawHorizontalPath(map, 10, 8, 20, TILES.COBBLESTONE);
+  drawHorizontalPath(map, 12, 8, 20, TILES.COBBLESTONE);
+  drawHorizontalPath(map, 15, 8, 20, TILES.COBBLESTONE);
+
+  fillRectangle(map, 6, 3, 8, 6, TILES.GRASS);
+  fillRectangle(map, 11, 9, 13, 11, TILES.GRASS);
+  fillRectangle(map, 13, 15, 14, 17, TILES.GRASS);
+
+  placeTile(map, 5, 3, TILES.AZURE_CHRONICLER);
+  placeTile(map, 5, 7, TILES.AZURE_SENTINEL);
+  placeTile(map, 5, 11, TILES.AZURE_CARTOGRAPHER);
+  placeTile(map, 5, 15, TILES.AZURE_TIDEGUARD);
+  placeTile(map, 5, 18, TILES.AZURE_BARD);
+
+  placeTile(map, 4, width - 3, TILES.AZURE_GATE);
+
+  placeTile(map, 9, 8, TILES.BOULDER);
+  placeTile(map, 9, 9, TILES.BOULDER);
+  placeTile(map, 14, 12, TILES.BOULDER);
+  placeTile(map, 15, 18, TILES.BOULDER);
+
+  return map;
+}
+
+function createCrimsonDunes(): number[][] {
+  const width = 24;
+  const height = 20;
+  const map = createFilledMap(width, height, TILES.SAND);
+  addBorder(map, TILES.SANDSTONE_SPIRE);
+
+  fillRectangle(map, 3, 6, 5, 7, TILES.SANDSTONE_SPIRE);
+  fillRectangle(map, 4, 13, 6, 15, TILES.SANDSTONE_SPIRE);
+  fillRectangle(map, 8, 2, 9, 5, TILES.OASIS_WATER);
+  fillRectangle(map, 10, 9, 12, 11, TILES.SANDSTONE_SPIRE);
+  fillRectangle(map, 11, 15, 13, 18, TILES.SANDSTONE_SPIRE);
+  fillRectangle(map, 13, 4, 15, 6, TILES.SANDSTONE_SPIRE);
+  fillRectangle(map, 14, 10, 16, 12, TILES.SANDSTONE_SPIRE);
+  fillRectangle(map, 7, 17, 8, 19, TILES.OASIS_WATER);
+
+  drawHorizontalPath(map, 9, 3, 20, TILES.COBBLESTONE);
+  drawVerticalPath(map, 6, 12, 12, TILES.COBBLESTONE);
+  drawVerticalPath(map, 12, 9, 16, TILES.COBBLESTONE);
+  drawVerticalPath(map, 20, 9, 15, TILES.COBBLESTONE);
+
+  placeTile(map, 4, 6, TILES.DESERT_STORYTELLER);
+  placeTile(map, 6, 11, TILES.DESERT_DUELIST);
+  placeTile(map, 8, 14, TILES.DESERT_NAVIGATOR);
+  placeTile(map, 11, 9, TILES.DESERT_BEASTMASTER);
+  placeTile(map, 14, 13, TILES.DESERT_ORACLE);
+
+  placeTile(map, 15, 20, TILES.DESERT_GATE);
+
+  return map;
+}
+
+function createLuminousGlade(): number[][] {
+  const width = 24;
+  const height = 20;
+  const map = createFilledMap(width, height, TILES.GLADE_GRASS);
+  addBorder(map, TILES.GLADE_TREE);
+
+  fillRectangle(map, 4, 5, 6, 8, TILES.GLADE_WATER);
+  fillRectangle(map, 8, 3, 9, 5, TILES.GLADE_WATER);
+  fillRectangle(map, 11, 14, 13, 17, TILES.GLADE_WATER);
+  fillRectangle(map, 6, 14, 7, 16, TILES.GLADE_TREE);
+  fillRectangle(map, 10, 9, 12, 11, TILES.GLADE_TREE);
+  fillRectangle(map, 14, 4, 16, 6, TILES.GLADE_TREE);
+
+  drawHorizontalPath(map, 15, 4, 20, TILES.COBBLESTONE);
+
+  placeTile(map, 5, 6, TILES.GLADE_HISTORIAN);
+  placeTile(map, 7, 14, TILES.GLADE_GUARDIAN);
+  placeTile(map, 9, 9, TILES.GLADE_SONGWEAVER);
+  placeTile(map, 12, 15, TILES.GLADE_SEER);
+  placeTile(map, 14, 8, TILES.GLADE_CARETAKER);
+
+  placeTile(map, 16, 20, TILES.GLADE_GATE);
+
+  return map;
+}
+
+export const levelOneMap = createVerdantFields();
+export const levelTwoMap = createAzureApproach();
+export const levelThreeMap = createCrimsonDunes();
+export const levelFourMap = createLuminousGlade();
 
 export interface LevelDefinition {
   id: string;
@@ -111,17 +529,33 @@ export const levels: LevelDefinition[] = [
     id: "verdant-fields",
     name: "Verdant Fields",
     description:
-      "A grassy meadow dotted with cobblestone paths and a mysterious wizard waiting near the grove.",
+      "A tranquil meadow of soft grass, winding cobblestone paths, and the grove sage who watches over the first waystone.",
     map: levelOneMap,
-    startingPosition: { row: 1, col: 1 },
+    startingPosition: { row: 2, col: 3 },
   },
   {
     id: "azure-approach",
     name: "Azure Approach",
     description:
-      "Cross wooden bridges and skirt deep waters to track down the traveling wizard at the shoreline camp.",
+      "Piers and islands linked by slick planks usher explorers across the bay toward storytellers of the tides.",
     map: levelTwoMap,
-    startingPosition: { row: 2, col: 2 },
+    startingPosition: { row: 4, col: 3 },
+  },
+  {
+    id: "crimson-dunes",
+    name: "Crimson Dunes",
+    description:
+      "Rolling dunes, oasis pools, and nomads of the desert test your resolve beneath a blazing sun.",
+    map: levelThreeMap,
+    startingPosition: { row: 3, col: 3 },
+  },
+  {
+    id: "luminous-glade",
+    name: "Luminous Glade",
+    description:
+      "Bioluminescent groves and crystalline ponds glow softly as guardians of light share the region's ancient lore.",
+    map: levelFourMap,
+    startingPosition: { row: 3, col: 3 },
   },
 ];
 

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -1,30 +1,120 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import GameCanvas from "./gameCanvas";
 import { DEFAULT_LEVEL, LevelId, levels } from "./mapData";
+import type { DialogueEntry } from "./eventData";
+
+interface LevelState {
+  id: LevelId;
+  entry: { row: number; col: number };
+}
 
 export default function GamePage() {
   const defaultLevel = DEFAULT_LEVEL;
-  const [selectedLevelId, setSelectedLevelId] = useState<LevelId>(
-    defaultLevel.id
-  );
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [dialogue, setDialogue] = useState<DialogueEntry | null>(null);
+  const [levelState, setLevelState] = useState<LevelState>(() => ({
+    id: defaultLevel.id as LevelId,
+    entry: { ...defaultLevel.startingPosition },
+  }));
 
   const activeLevel = useMemo(() => {
-    const next = levels.find((lvl) => lvl.id === selectedLevelId);
+    const next = levels.find((lvl) => lvl.id === levelState.id);
     return next ?? defaultLevel;
-  }, [selectedLevelId, defaultLevel]);
+  }, [levelState.id, defaultLevel]);
+
+  const handleSelectLevel = useCallback(
+    (levelId: LevelId) => {
+      const targetLevel = levels.find((lvl) => lvl.id === levelId);
+      if (!targetLevel) {
+        return;
+      }
+      setDialogue(null);
+      setLevelState({
+        id: targetLevel.id as LevelId,
+        entry: { ...targetLevel.startingPosition },
+      });
+    },
+    []
+  );
+
+  const handleLevelTransition = useCallback(
+    (transition: { targetLevelId: string; spawn?: { row: number; col: number } }) => {
+      const target = levels.find((lvl) => lvl.id === transition.targetLevelId);
+      if (!target) {
+        return;
+      }
+      setDialogue(null);
+      setLevelState({
+        id: target.id as LevelId,
+        entry: transition.spawn
+          ? { ...transition.spawn }
+          : { ...target.startingPosition },
+      });
+    },
+    []
+  );
+
+  const openDialogue = useCallback((entry: DialogueEntry) => {
+    setDialogue(entry);
+  }, []);
+
+  const levelFromParams = searchParams.get("level");
+  useEffect(() => {
+    if (!levelFromParams || levelFromParams === levelState.id) {
+      return;
+    }
+    const match = levels.find((lvl) => lvl.id === levelFromParams);
+    if (match) {
+      setLevelState({
+        id: match.id as LevelId,
+        entry: { ...match.startingPosition },
+      });
+    }
+  }, [levelFromParams, levelState.id]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(Array.from(searchParams.entries()));
+    params.set("level", levelState.id);
+    router.replace(`?${params.toString()}`, { scroll: false });
+  }, [router, searchParams, levelState.id]);
+
+  useEffect(() => {
+    if (!dialogue) {
+      return;
+    }
+    function handleClose(e: KeyboardEvent) {
+      if (e.key === "Escape" || e.key === "Enter") {
+        setDialogue(null);
+      }
+    }
+    window.addEventListener("keydown", handleClose);
+    return () => window.removeEventListener("keydown", handleClose);
+  }, [dialogue]);
 
   return (
     <main className="overflow-x-hidden flex flex-col items-center gap-6 p-6">
       <section className="text-center space-y-2">
         <h1 className="text-3xl font-bold tracking-tight">Adventure Levels</h1>
         <p className="text-sm text-neutral-600 dark:text-neutral-300 max-w-2xl mx-auto">
-          Use the arrow keys or WASD to explore the overworld. Select a level to
-          instantly travel to a new area of the region.
+          Use the arrow keys or WASD to explore, then press Enter or Space to
+          speak with NPCs or activate waystones. Select a level to instantly
+          travel, or walk through the world to discover each biome in sequence.
         </p>
       </section>
-      <div className="flex flex-wrap justify-center gap-3" role="tablist" aria-label="Level selector">
+      <div
+        className="flex flex-wrap justify-center gap-3"
+        role="tablist"
+        aria-label="Level selector"
+      >
         {levels.map((levelOption) => {
           const isActive = levelOption.id === activeLevel.id;
           return (
@@ -33,7 +123,7 @@ export default function GamePage() {
               type="button"
               role="tab"
               aria-selected={isActive}
-              onClick={() => setSelectedLevelId(levelOption.id)}
+              onClick={() => handleSelectLevel(levelOption.id as LevelId)}
               className={`rounded-full px-4 py-2 text-sm font-semibold border transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 ${
                 isActive
                   ? "bg-blue-500 border-blue-500 text-white shadow"
@@ -48,7 +138,34 @@ export default function GamePage() {
       <p className="text-sm text-neutral-500 dark:text-neutral-300 max-w-3xl text-center">
         {activeLevel.description}
       </p>
-      <GameCanvas level={activeLevel} />
+      <GameCanvas
+        level={activeLevel}
+        entryPosition={levelState.entry}
+        onLevelChange={handleLevelTransition}
+        onDialogue={openDialogue}
+        isInputDisabled={Boolean(dialogue)}
+      />
+      {dialogue && (
+        <div className="fixed inset-0 z-10 flex items-end justify-center bg-black/40 px-4 pb-8">
+          <div className="w-full max-w-2xl rounded-lg border border-neutral-700 bg-neutral-900/90 p-6 text-neutral-100 shadow-2xl">
+            <h2 className="text-lg font-semibold">{dialogue.name}</h2>
+            <div className="mt-3 space-y-2 text-sm leading-relaxed">
+              {dialogue.lines.map((line, index) => (
+                <p key={index}>{line}</p>
+              ))}
+            </div>
+            <div className="mt-5 flex justify-end">
+              <button
+                type="button"
+                onClick={() => setDialogue(null)}
+                className="rounded-md bg-blue-500 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-400"
+              >
+                Fechar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- expand map data with reusable tile definitions, two additional biomes, and event metadata for dialogues, portals, and battles
- load encounter and dialogue content, update the overworld canvas to handle interactions, and surface lore via a dialogue overlay
- create a turn-based battle screen that uses existing sprites and attack data when players challenge hostile NPCs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c91cb0d3f48331af9574515a9df7dc